### PR TITLE
(fix) Multiple issues in container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,5 @@ Dockerfile*
 **/*.sh
 global.json
 
-**/packages.lock.json
 **/appsettings.*.json
 !**/appsettings.Production.json

--- a/AzureKeyVaultEmulator/Startup.cs
+++ b/AzureKeyVaultEmulator/Startup.cs
@@ -112,14 +112,9 @@ internal sealed class Startup
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
-        if (env.IsDevelopment())
-        {
-            app.UseDeveloperExceptionPage();
-            app.UseSwagger();
-            app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Azure KeyVault Emulator v1"));
-        }
-
-        app.UseHttpsRedirection();
+        app.UseDeveloperExceptionPage();
+        app.UseSwagger();
+        app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Azure KeyVault Emulator v1"));
 
         app.UseRouting();
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0-noble AS build
 WORKDIR /app
 
 COPY AzureKeyVaultEmulator/AzureKeyVaultEmulator.csproj ./AzureKeyVaultEmulator/
+COPY AzureKeyVaultEmulator/packages.lock.json ./AzureKeyVaultEmulator/
 RUN dotnet restore AzureKeyVaultEmulator/AzureKeyVaultEmulator.csproj \
         --use-lock-file --locked-mode
 
 COPY . .
 RUN dotnet publish AzureKeyVaultEmulator/AzureKeyVaultEmulator.csproj \
         -c Release -o publish --no-restore && \
+    rm /app/publish/packages.lock.json && \
     mkdir -p /app/publish/.vault
 
 ########################################
@@ -16,6 +18,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled
 WORKDIR /app
 
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true
+ENV ASPNETCORE_URLS=http://+:11000;https://+:11001
 ENTRYPOINT ["dotnet", "AzureKeyVaultEmulator.dll"]
 VOLUME ["/app/.vault"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,8 @@ services:
     hostname: azure-keyvault-emulator.vault.azure.net
     ports:
       - 11001:11001
-      - 11000:11000
     volumes:
       - $PWD/local-certs:/https:ro
     environment:
-      - ASPNETCORE_URLS=https://+:11001
       - ASPNETCORE_Kestrel__Certificates__Default__KeyPath=/https/azure-keyvault-emulator.key
       - ASPNETCORE_Kestrel__Certificates__Default__Path=/https/azure-keyvault-emulator.crt


### PR DESCRIPTION
- Swagger UI is not loaded for non-Development environments
- packages.lock.json is needed for restore during build stage
- Default to HTTP on port 11000 and HTTPS on 11001