### PR TITLE
(fix) Bugs in keys and secrets controllers

### DIFF
--- a/src/AzureKeyVaultEmulator/Controllers/KeysControllerImpl.cs
+++ b/src/AzureKeyVaultEmulator/Controllers/KeysControllerImpl.cs
@@ -200,7 +200,10 @@ internal sealed partial class KeysControllerImpl(
 
         if (null == keys)
         {
-            return new NotFoundResult();
+            // The documentation isn't very clear about this, but the actual
+            // Key Vault APIs do NOT respond with a 404 (Not Found) when the
+            // key doesn't exist. Instead, they just return an empty page.
+            keys = [];
         }
 
         return await ListKeysAsync(keys, cancellationToken);

--- a/src/AzureKeyVaultEmulator/Controllers/SecretsControllerImpl.cs
+++ b/src/AzureKeyVaultEmulator/Controllers/SecretsControllerImpl.cs
@@ -140,7 +140,10 @@ internal sealed partial class SecretsControllerImpl(
 
         if (null == secrets)
         {
-            return new NotFoundResult();
+            // The documentation isn't very clear about this, but the actual
+            // Key Vault APIs do NOT respond with a 404 (Not Found) when the
+            // secret doesn't exist. Instead, they just return an empty page.
+            secrets = [];
         }
 
         return await ListSecretsAsync(secrets, cancellationToken);

--- a/test/AzureKeyVaultEmulator.AcceptanceTests/ApiTests/KeysApisTests.GetKeyVersions.cs
+++ b/test/AzureKeyVaultEmulator.AcceptanceTests/ApiTests/KeysApisTests.GetKeyVersions.cs
@@ -28,14 +28,13 @@ partial class KeysApisTests
     }
 
     [Fact]
-    public async Task GetKeyVersionsReturns404ForInexistentKey()
+    public async Task GetKeyVersionsReturnsEmptyPageForInexistentKey()
     {
         string name = Guid.NewGuid().ToString();
 
         AsyncPageable<KeyProperties> versions = client.GetPropertiesOfKeyVersionsAsync(name);
         IAsyncEnumerator<KeyProperties> enumerator = versions.GetAsyncEnumerator();
-        RequestFailedException ex = await Assert.ThrowsAsync<RequestFailedException>(
-            () => enumerator.MoveNextAsync().AsTask());
-        Assert.Equal(404, ex.Status);
+        Assert.False(await enumerator.MoveNextAsync());
+        Assert.Empty(versions.ToBlockingEnumerable(default));
     }
 }

--- a/test/AzureKeyVaultEmulator.AcceptanceTests/ApiTests/SecretsApisTests.GetSecretVersions.cs
+++ b/test/AzureKeyVaultEmulator.AcceptanceTests/ApiTests/SecretsApisTests.GetSecretVersions.cs
@@ -28,14 +28,13 @@ partial class SecretsApisTests
     }
 
     [Fact]
-    public async Task GetSecretVersionsReturns404ForInexistentSecret()
+    public async Task GetSecretVersionsReturnsEmptyPageForInexistentSecret()
     {
         string name = Guid.NewGuid().ToString();
 
         AsyncPageable<SecretProperties> versions = client.GetPropertiesOfSecretVersionsAsync(name);
         IAsyncEnumerator<SecretProperties> enumerator = versions.GetAsyncEnumerator();
-        RequestFailedException ex = await Assert.ThrowsAsync<RequestFailedException>(
-            () => enumerator.MoveNextAsync().AsTask());
-        Assert.Equal(404, ex.Status);
+        Assert.False(await enumerator.MoveNextAsync());
+        Assert.Empty(versions.ToBlockingEnumerable(default));
     }
 }


### PR DESCRIPTION
Return an empty page when a key's/a secret's versions are requested and the key/secret does not exist. This behavior is aligned with the behavior of Azure Key Vault APIs.